### PR TITLE
Add CHROME_PATH env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,13 +86,15 @@ Follow these steps to get the BrowserX Agent running on your local machine.
     ```
 
 3.  **Set up your environment variables:**
-    Create a file named `.env` in the root of the project directory. This file will hold your OpenAI API key.
+    Create a file named `.env` in the root of the project directory. This file holds your OpenAI API key and optional configuration values.
 
     ```ini
     # .env
     OPENAI_API_KEY="sk-YourSecretOpenAIApiKeyHere"
+    # Optional: specify the path to your Chrome executable
+    CHROME_PATH="/path/to/google-chrome"
     ```
-    *Replace the placeholder with your actual OpenAI API key.*
+    *Replace the placeholders with your actual values. `CHROME_PATH` defaults to a common location for your operating system if omitted.*
 
 4.  **Run the application:**
     ```bash

--- a/puppeteer_executor.js
+++ b/puppeteer_executor.js
@@ -3,6 +3,14 @@
 const fs = require('fs');
 const path = require('path');
 const puppeteer = require('puppeteer');
+
+const DEFAULT_CHROME_PATHS = {
+  win32: 'C\\\Program Files\\\Google\\\Chrome\\\Application\\\chrome.exe',
+  darwin: '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+  linux: '/usr/bin/google-chrome'
+};
+
+const CHROME_PATH = process.env.CHROME_PATH || DEFAULT_CHROME_PATHS[process.platform] || '/usr/bin/google-chrome';
 const { createPlan, decideNextBrowserAction } = require('./agent_api.js'); // Import createPlan here
 
 const USER_DATA_DIR = path.join(__dirname, 'chrome_session_data');
@@ -58,12 +66,12 @@ async function simplifyHtml(page) {
 // +++ THIS IS THE CORRECTED FUNCTION WITH DYNAMIC RE-PLANNING +++
 async function runAutonomousAgent(startUrl, taskSummary, strategy, onLog, agentControl) {
   onLog(`🚀 Launching browser with persistent session data...`);
-  const browser = await puppeteer.launch({ 
-    headless: false, 
-    executablePath: '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome', 
-    args: ['--no-sandbox', '--disable-setuid-sandbox', '--start-maximized'], 
-    userDataDir: USER_DATA_DIR, 
-    defaultViewport: null 
+  const browser = await puppeteer.launch({
+    headless: false,
+    executablePath: CHROME_PATH,
+    args: ['--no-sandbox', '--disable-setuid-sandbox', '--start-maximized'],
+    userDataDir: USER_DATA_DIR,
+    defaultViewport: null
   });
   
   let page = null;


### PR DESCRIPTION
## Summary
- support `CHROME_PATH` env var for Puppeteer
- document the new variable in the setup instructions

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684bef6729f48321b1892a749eb9ac6d