### PR TITLE
Make port configurable and adjust QR endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ Follow these steps to get the BrowserX Agent running on your local machine.
     ```ini
     # .env
     OPENAI_API_KEY="sk-YourSecretOpenAIApiKeyHere"
+    # Optionally override the default port (3000)
+    PORT=8080
     ```
     *Replace the placeholder with your actual OpenAI API key.*
 
@@ -122,6 +124,7 @@ This tab shows a list of all tasks you have run, along with their status: `Compl
 -   To control the agent from your phone, navigate to this tab on your desktop.
 -   Open the camera app on your phone and scan the QR code.
 -   This will open the web interface in your phone's browser, giving you full control.
+-   If you need the code manually, visit `http://<your-ip>:PORT/api/qr-code`.
 -   **Note:** Your phone must be connected to the same Wi-Fi network as your computer.
 
 ## Future Improvements

--- a/main.js
+++ b/main.js
@@ -12,7 +12,7 @@ const qrcode = require('qrcode'); // +++ NEW
 const { createPlan } = require('./agent_api.js');
 const { runAutonomousAgent } = require('./puppeteer_executor.js');
 
-const PORT = 3000;
+const PORT = process.env.PORT || 3000;
 const agentControl = { stop: false };
 
 function getLocalIpAddress() {
@@ -57,8 +57,8 @@ function createWindow() {
 
     // --- API ENDPOINTS ---
     
-    // +++ THIS IS THE NEW ENDPOINT +++
-    expressApp.get('/api/get-qr-code', async (req, res) => {
+    // +++ QR code endpoint +++
+    expressApp.get('/api/qr-code', async (req, res) => {
         try {
             const qrCodeDataUrl = await qrcode.toDataURL(serverUrl, {
                 errorCorrectionLevel: 'H',

--- a/renderer.js
+++ b/renderer.js
@@ -116,7 +116,7 @@ const fetchQrCode = async () => {
     qrCodeImage.classList.add('d-none');
 
     try {
-        const response = await fetch('/api/get-qr-code');
+        const response = await fetch('/api/qr-code');
         const data = await response.json();
         if (data.success) {
             qrCodeImage.src = data.qrCode;


### PR DESCRIPTION
## Summary
- allow overriding the default port via `PORT`
- rename QR-code API endpoint to `/api/qr-code`
- mention new endpoint and environment variable in README

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684bef6c9084832199c5af899334d0f4