### PR TITLE
Add API key check on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Follow these steps to get the BrowserX Agent running on your local machine.
     OPENAI_API_KEY="sk-YourSecretOpenAIApiKeyHere"
     ```
     *Replace the placeholder with your actual OpenAI API key.*
+    If this variable is missing, the application will log an error and exit on startup.
 
 4.  **Run the application:**
     ```bash

--- a/main.js
+++ b/main.js
@@ -2,6 +2,12 @@
 
 require('dotenv').config();
 
+if (!process.env.OPENAI_API_KEY) {
+    console.error('Error: OPENAI_API_KEY environment variable is not set.');
+    console.error('Create a .env file with OPENAI_API_KEY or set it in your environment.');
+    process.exit(1);
+}
+
 const { app, BrowserWindow } = require('electron');
 const path = require('path');
 const http = require('http');


### PR DESCRIPTION
## Summary
- error and exit if `OPENAI_API_KEY` is missing
- document the required env var in the README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684bef715f0c832186537332d95940ba